### PR TITLE
Specify dataset to determine which halos to keep

### DIFF
--- a/reduce_snapshots.cpp
+++ b/reduce_snapshots.cpp
@@ -632,9 +632,12 @@ public:
    * variable Overdensity_output_maximum_radius_in_critical_density. But again,
    * any possible valid array would work (including those that do not represent
    * any radius at all, so be careful - again!).
+   * @param keep_selection_name Name of the array in the .properties file that
+   * will be used to determine which halos to keep
    * @param memory MemoryLogBlock used to log memory usage.
    */
   SOTable(const std::string prefix, const std::string radius_selection_name,
+          const std::string keep_selection_name,
           MemoryLog::MemoryLogBlock &memory)
       : _prefix(prefix) {
 
@@ -732,8 +735,15 @@ public:
       }
       CofP.clear();
 
-      HDF5FileOrGroup SOAPgroup = OpenGroup(file, "SOAP");
-      ReadEntireDataset(SOAPgroup, "IncludedInReducedSnapshot", keep);
+      if (keep_selection_name == "SOAP/IncludedInReducedSnapshot") {
+        HDF5FileOrGroup SOAPgroup = OpenGroup(file, "SOAP");
+        ReadEntireDataset(SOAPgroup, "IncludedInReducedSnapshot", keep);
+      } else if (keep_selection_name == "InputHalos/IsCentral") {
+        HDF5FileOrGroup SOAPgroup = OpenGroup(file, "InputHalos");
+        ReadEntireDataset(SOAPgroup, "IsCentral", keep);
+      } else {
+        my_error("Invalid keep_selection_name");
+      }
 
       {
         const auto radius_path = decompose_dataset_path(radius_selection_name);
@@ -979,7 +989,8 @@ int main(int argc, char **argv) {
       std::cerr << "Usage: ./reduce_snapshots SOAP_OUTPUT_PREFIX "
                    "SNAPSHOT_FILE_PREFIX MEMBERSHIP__FILE_PREFIX "
                    "OUTPUT_FILE_PREFIX "
-                   "RADIUS_SELECTION_NAME [CELLBUFSIZE] "
+                   "RADIUS_SELECTION_NAME "
+                   "KEEP_SELECTION_NAME [CELLBUFSIZE] "
                    "[HDF5BUFSIZE]"
                 << std::endl;
     }
@@ -990,8 +1001,9 @@ int main(int argc, char **argv) {
   const std::string membership_file_prefix(argv[3]);
   const std::string output_file_prefix(argv[4]);
   std::string radius_selection_name(argv[5]);
-  const uint32_t cellbufsize = (argc > 6) ? atoi(argv[6]) : 8;
-  const size_t hdf5bufsize = (argc > 7) ? atoll(argv[7]) : -1;
+  std::string keep_selection_name(argv[6]);
+  const uint32_t cellbufsize = (argc > 7) ? atoi(argv[7]) : 8;
+  const size_t hdf5bufsize = (argc > 8) ? atoll(argv[8]) : -1;
 
   const std::string catalog_file = find_file(SOAP_output_prefix, "");
   //  const std::string siminfo_file = find_file(SOAP_output_prefix, ".siminfo");
@@ -1020,6 +1032,8 @@ int main(int argc, char **argv) {
             output_file_prefix.c_str());
     timelog(LOGLEVEL_GENERAL, "Radius selection name: %s",
             radius_selection_name.c_str());
+    timelog(LOGLEVEL_GENERAL, "Keep selection name: %s",
+            keep_selection_name.c_str());
     timelog(LOGLEVEL_GENERAL, "Cellbufsize: %u", cellbufsize);
     timelog(LOGLEVEL_GENERAL, "HDF5bufsize: %s",
             human_readable_bytes(hdf5bufsize).c_str());
@@ -1051,7 +1065,7 @@ int main(int argc, char **argv) {
   }
 
   // read the SOTable: this is the entire first step mentioned above
-  const SOTable SOtable(SOAP_output_prefix, radius_selection_name, memory);
+  const SOTable SOtable(SOAP_output_prefix, radius_selection_name, keep_selection_name, memory);
 
   MPI_Barrier(MPI_COMM_WORLD);
 

--- a/scripts/reduce_snapshots_L1000N1800.sh
+++ b/scripts/reduce_snapshots_L1000N1800.sh
@@ -44,6 +44,9 @@ out="${outdir}/flamingo_${snapnum}/flamingo_${snapnum}"
 # radius variable inside which particles are kept
 RlimVar=SO/100_crit/SORadius
 
+# property variable to detemine which halos to keep
+KeepVar=SOAP/IncludedInReducedSnapshot
+
 # number of SWIFT cells that is processed in one go
 # a larger number is better for performance, while a smaller number is better
 # for memory usage
@@ -62,6 +65,6 @@ export I_MPI_THREAD_YIELD=2
 
 # note that the number of ranks cannot exceed the number of snapshot files,
 mpirun -- ${code} ${cat} ${snap} ${mem} ${out} \
-  ${RlimVar} ${Ncell} ${block_size}
+  ${RlimVar} ${KeepVar} ${Ncell} ${block_size}
 
 echo "Job complete!"

--- a/scripts/reduce_snapshots_L1000N3600.sh
+++ b/scripts/reduce_snapshots_L1000N3600.sh
@@ -44,6 +44,9 @@ out="${outdir}/flamingo_${snapnum}/flamingo_${snapnum}"
 # radius variable inside which particles are kept
 RlimVar=SO/100_crit/SORadius
 
+# property variable to detemine which halos to keep
+KeepVar=SOAP/IncludedInReducedSnapshot
+
 # number of SWIFT cells that is processed in one go
 # a larger number is better for performance, while a smaller number is better
 # for memory usage
@@ -62,7 +65,7 @@ export I_MPI_THREAD_YIELD=2
 
 # note that the number of ranks cannot exceed the number of snapshot files,
 mpirun -- ${code} ${cat} ${snap} ${mem} ${out} \
-  ${RlimVar} ${Ncell} ${block_size}
+  ${RlimVar} ${KeepVar} ${Ncell} ${block_size}
 
 echo "Job complete!"
 

--- a/scripts/reduce_snapshots_L2800N5040.sh
+++ b/scripts/reduce_snapshots_L2800N5040.sh
@@ -44,6 +44,9 @@ out="${outdir}/flamingo_${snapnum}/flamingo_${snapnum}"
 # radius variable inside which particles are kept
 RlimVar=SO/100_crit/SORadius
 
+# property variable to detemine which halos to keep
+KeepVar=SOAP/IncludedInReducedSnapshot
+
 # number of SWIFT cells that is processed in one go
 # a larger number is better for performance, while a smaller number is better
 # for memory usage
@@ -62,6 +65,6 @@ export I_MPI_THREAD_YIELD=2
 
 # note that the number of ranks cannot exceed the number of snapshot files,
 mpirun -- ${code} ${cat} ${snap} ${mem} ${out} \
-  ${RlimVar} ${Ncell} ${block_size}
+  ${RlimVar} ${KeepVar} ${Ncell} ${block_size}
 
 echo "Job complete!"

--- a/scripts/reduce_snapshots_L5600N5040.sh
+++ b/scripts/reduce_snapshots_L5600N5040.sh
@@ -47,6 +47,9 @@ out="${outdir}/flamingo_${snapnum}/flamingo_${snapnum}"
 # and many objects don't since this run is such low resolution
 RlimVar=SO/200_crit/SORadius
 
+# property variable to detemine which halos to keep
+KeepVar=SOAP/IncludedInReducedSnapshot
+
 # number of SWIFT cells that is processed in one go
 # a larger number is better for performance, while a smaller number is better
 # for memory usage
@@ -65,6 +68,6 @@ export I_MPI_THREAD_YIELD=2
 
 # note that the number of ranks cannot exceed the number of snapshot files,
 mpirun -- ${code} ${cat} ${snap} ${mem} ${out} \
-  ${RlimVar} ${Ncell} ${block_size}
+  ${RlimVar} ${KeepVar} ${Ncell} ${block_size}
 
 echo "Job complete!"


### PR DESCRIPTION
Revert https://github.com/SWIFTSIM/ReduceSnapshots/commit/2a1a5e97bf72ddad722ef9ad251b4f71faf6eb18 as code would not compile, and we now have https://github.com/SWIFTSIM/ReduceSnapshots/pull/3

Add the option to pass the dataset name for determining which halos to keep 